### PR TITLE
Un 165 fix keyboard inputs on i os and android

### DIFF
--- a/src/screens/CreateListingScreen/index.js
+++ b/src/screens/CreateListingScreen/index.js
@@ -14,6 +14,7 @@ import CategorySelect from '../../components/CategorySelect';
 import {UIImagePickerPresentationStyle} from "expo-image-picker";
 import {useForm} from "react-hook-form";
 import DropDownPicker from "react-native-dropdown-picker";
+import { TouchableWithoutFeedback, Keyboard } from 'react-native';
 
 
 const CreateListingScreen = () => {
@@ -109,6 +110,8 @@ const CreateListingScreen = () => {
 
     // had scroll view to permit tapping out of text boxes. try to find keyboard dismiss. also figure out how to keep default camera image on pickimage. implement multiople images as well. /clear fields after publishing successfully. require fileds too
     return (
+
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
         <View>
             <View style = {styles.container}>
                 <TouchableOpacity onPress={pickImage}>
@@ -169,6 +172,7 @@ const CreateListingScreen = () => {
                         setValue={setValue}
                         setItems={setItems}
                         multiple={false}
+                        dropDownDirection="TOP"
                         onChangeValue={(value) => {
                             setPickedCategory(value);
                         }}
@@ -177,6 +181,7 @@ const CreateListingScreen = () => {
                 <CustomButton onPress= {publishListing} text  = {"Publish Listing"}/>
             </View>
         </View>
+        </TouchableWithoutFeedback>
     );
 };
 

--- a/src/screens/ProfileScreen/index.js
+++ b/src/screens/ProfileScreen/index.js
@@ -14,6 +14,7 @@ import AuthContext from "../../contexts/Authentication";
 import CustomTextBox from "../../components/CustomTextBox";
 import CustomButton from "../../components/CustomButton";
 import { useForm } from "react-hook-form";
+import { TouchableWithoutFeedback, Keyboard } from 'react-native';
 
 
 const ProfilePage = () => {
@@ -240,6 +241,7 @@ const ProfilePage = () => {
                 presentationStyle="overFullScreen"
                 onDsimiss={toggleModalVisibility}
               >
+                <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
                 <View style={styles.viewWrapper}>
                   <View style={styles.modalView}>
                     <CustomTextBox
@@ -260,6 +262,7 @@ const ProfilePage = () => {
                     />
                   </View>
                 </View>
+                </TouchableWithoutFeedback>
               </Modal>
             </View>
           </View>


### PR DESCRIPTION
Fixed keyboard on iOS so now you can tap anywhere on the screen to hide the keyboard in the create listing screen and edit bio on profile.

Also added a prop to categories dropdownbox on create listing screen to make sure it opens upwards and not downwards