### PR TITLE
Removed extra nested navigators from homestack

### DIFF
--- a/src/components/ProductDetails/index.js
+++ b/src/components/ProductDetails/index.js
@@ -106,10 +106,7 @@ const ProductDetails = () => {
                         </Text>
                     </View>
                     <View style={styles.profileContainer}>
-                        <TouchableOpacity onPress={() => navigation.navigate("OtherProfileNavStack", {
-                            screen: "OtherProfileScreen",
-                            params: {userSub: product.userSub}
-                        })}>
+                        <TouchableOpacity onPress={() => navigation.navigate("OtherProfileScreen", {userSub: product.userSub})}>
                             <View style={styles.profileContainer2}>
                                 {/*<Image style = {styles.circleButtonPic} source = {require("../../../assets/user.png")}/>*/}
                                 <S3Image style={styles.circleButtonPic} imgKey={profileImage}/>
@@ -132,23 +129,9 @@ const ProductDetails = () => {
                     <View style={styles.buttonContainer}>
                         <ScaledCustomButton onPress={addToSavedList} text='Save Listing' primary={true}/>
 
-                        {/*<CustomButton onPress={() => {*/}
-                        {/*    // console.log("Product Details screen: " + product.id)*/}
-                        {/*    // console.log("Product Details screen: " + product.title)*/}
-                        {/*    // console.log("Product Details screen: " + product.price)*/}
-                        {/*    // console.log("Product Details screen: " + product.description)*/}
-                        {/*    navigation.navigate('EditProductScreen',*/}
-                        {/*        {*/}
-                        {/*            id: product.id,*/}
-                        {/*            title: product.title,*/}
-                        {/*            price: product.price,*/}
-                        {/*            description: product.description*/}
-                        {/*        }*/}
-                        {/*    )*/}
-                        {/*}}*/}
-                        {/*    text="Edit" />*/}
+                        
                         <SendMessageItem userToMessage={sellingUser}/>
-                        {/*<CustomButton onPress = {addToSavedList} text = 'Profile'/>*/}
+                        
                     </View>
                 </ScrollView>
             </SafeAreaView>

--- a/src/components/ProductItem/index.js
+++ b/src/components/ProductItem/index.js
@@ -11,9 +11,7 @@ const ProductItem = ({ id, image, title, price, displayName, createdAt }) => {
   const navigation = useNavigation();
   const onPress = () => {
     // which exact product, passing params lets us send data, but we must also receive data in product details screen for proper function
-    navigation.navigate("ProductScreen", { 
-      screen: 'ProductDetails',
-      params: {id: id, title: title, price: price}});
+    navigation.navigate("ProductDetails", {id: id, title: title, price: price});
   };
   const compareDate = () => {
     

--- a/src/navigation/HomeStack.js
+++ b/src/navigation/HomeStack.js
@@ -4,10 +4,15 @@ import HomeScreen from '../screens/HomeScreen';
 import { SafeAreaView, TextInput, View } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { Colors } from '../styles/Colors';
-import NotificationsButton from '../components/NotificationsButton';
-import NotificationsScreen from '../screens/NotificationsScreen';
-import ProductDetailScreenStack from './ProductDetailsStack';
+import ReportScreen from '../screens/ReportScreen';
 import SchoolLogo from '../components/SchoolLogo';
+import ProductDetails from '../components/ProductDetails';
+import EditProductScreen from '../screens/EditProductScreen';
+import ChatScreen from '../screens/ChatScreen';
+import ReviewScreen from '../screens/ReviewScreen';
+import ActiveListingScreen from '../screens/ActiveListingScreen';
+import LeaveReviewScreen from '../screens/LeaveReviewScreen';
+import OtherProfileScreen from '../screens/OtherProfileScreen'
 const Stack = createStackNavigator();
 
 const HeaderComponent = ({search, setSearch}) => {
@@ -40,7 +45,16 @@ const HomeStack = () => {
                     () => <HomeScreen searchValue={search}/>
                 }
             </Stack.Screen>
-            <Stack.Screen name='ProductScreen' component={ProductDetailScreenStack} options={{headerShown: true, title: '' }} />
+
+            <Stack.Screen name="ProductDetails" component={ProductDetails} options={{title:'Product Detail'}}/>
+            <Stack.Screen name="EditProductScreen" component={EditProductScreen} options={{title:'Edit Product'}}/>
+            <Stack.Screen name='OtherProfileScreen' component={OtherProfileScreen} options= {{title: ''}}/>
+            <Stack.Screen name='ReportScreen' component={ReportScreen}/>
+            <Stack.Screen name='ReviewScreen' component={ReviewScreen}/>
+            <Stack.Screen name='ActiveListingScreen' component={ActiveListingScreen}/>
+            <Stack.Screen name='LeaveReviewScreen' component={LeaveReviewScreen} />
+            <Stack.Screen name="Chat" component={ChatScreen} options={{title:'Chat'}}/>
+            
             {/* <Stack.Screen component={NotificationsScreen} name={"Notifications"} options={{ title: 'Notifications' }} />  */}
         </Stack.Navigator>
 

--- a/src/navigation/ProfileStack.js
+++ b/src/navigation/ProfileStack.js
@@ -29,7 +29,6 @@ const ProfileScreenStack = () => {
             <ProfileStack.Screen name="ResetPassword" component={ResetPasswordScreen} />
             <ProfileStack.Screen name="SignIn" component={SignInScreen} />
             <ProfileStack.Screen name='ReportScreen' component={ReportScreen}/>
-             {/*<.Screen name='ProductScreen' component={ProductDetails} options={{ title: '' }} /> */}
         </ProfileStack.Navigator>
 
     );

--- a/src/screens/OtherProfileScreen/index.js
+++ b/src/screens/OtherProfileScreen/index.js
@@ -130,7 +130,7 @@ const [isLoading, setIsLoading] = useState(true);
 
               <View style={styles.reportContainer}>
                 <TouchableOpacity
-                  onPress={() => navigation.navigate('ProductDetails', {screen : "ReportScreen"})}
+                  onPress={() => navigation.navigate("ReportScreen")}
                 >
                   <MaterialIcons
                     style={styles.reportIconContainer}


### PR DESCRIPTION
I removed ProductDetailsStack and OtherProfileNavStack from the HomeStack. This removes the goofy double back buttons, as well as back arrow not taking you back to correct locations. To test this, click on a product:
- try to send a message to the user from product screen
- navigate to another user's profile, and click all the links available on that profile