### PR TITLE
Un 121 

### DIFF
--- a/src/screens/SignUpScreen/index.js
+++ b/src/screens/SignUpScreen/index.js
@@ -101,7 +101,6 @@ const SignUpScreen = () => {
            
             return true;
         } else {
-            alert("Invalid email address");
             return false;
         }
     }


### PR DESCRIPTION
The problem was: After the invalid email alert shows up it continues to pop up after every character change in the email field.

To test:
- navigate to sign up screen
- enter an invalid email address (say, gmail address)
- fill out other fields correctly
- click submit
- an error will pop up under email field
- when you change email, you will not continually be prompted with an alert message