### PR TITLE
Fixed navigation when clicking back button from active listings screen

### DIFF
--- a/src/components/ActiveProductItem/index.js
+++ b/src/components/ActiveProductItem/index.js
@@ -11,7 +11,7 @@ const ActiveProductItem = ({ id, image, title, price, items, setItems }) => {
   const navigation = useNavigation();
   const onPress = () => {
     // which exact product, passing params lets us send data, but we must also receive data in product details screen for proper function
-    navigation.navigate("ProductScreen", { id: id });
+    navigation.navigate("OtherProductDetails", { id: id });
   };
 
   const deleteItemById = async (id) => {

--- a/src/navigation/HomeStack.js
+++ b/src/navigation/HomeStack.js
@@ -54,6 +54,7 @@ const HomeStack = () => {
             <Stack.Screen name='ActiveListingScreen' component={ActiveListingScreen}/>
             <Stack.Screen name='LeaveReviewScreen' component={LeaveReviewScreen} />
             <Stack.Screen name="Chat" component={ChatScreen} options={{title:'Chat'}}/>
+            <Stack.Screen name="OtherProductDetails" component={ProductDetails} options={{title:'Product Detail'}}/>
             
             {/* <Stack.Screen component={NotificationsScreen} name={"Notifications"} options={{ title: 'Notifications' }} />  */}
         </Stack.Navigator>

--- a/src/navigation/ProfileStack.js
+++ b/src/navigation/ProfileStack.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
 import ProfilePage from '../screens/ProfileScreen';
-import SavedItemScreen from '../screens/SavedItemsScreen';
-import SavedItemStack from './SavedItemStack';
+import ProductDetails from '../components/ProductDetails';
 import ForgotPasswordScreen from '../screens/ForgotPasswordScreen';
 import SettingsScreen from '../screens/SettingsScreen';
 import ResetPasswordScreen from '../screens/ResetPasswordScreen';
@@ -29,6 +28,7 @@ const ProfileScreenStack = () => {
             <ProfileStack.Screen name="ResetPassword" component={ResetPasswordScreen} />
             <ProfileStack.Screen name="SignIn" component={SignInScreen} />
             <ProfileStack.Screen name='ReportScreen' component={ReportScreen}/>
+            <ProfileStack.Screen name="OtherProductDetails" component={ProductDetails} options={{title:'Product Detail'}}/>
         </ProfileStack.Navigator>
 
     );


### PR DESCRIPTION
To test:
- navigate to your profile screen
- click active listings
- click on a listing
- click back
- you should be back to the active listings screen
- navigate to home screen
- click on a product
- open another person's profile
- click on their active listings
- click on a listing
- click back
- you should be on their active listings screen again